### PR TITLE
Switch behat class to use trait

### DIFF
--- a/tests/behat/behat_editor_tiny_multilang2.php
+++ b/tests/behat/behat_editor_tiny_multilang2.php
@@ -29,13 +29,15 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../../../tests/behat/behat_editor_tiny.php');
+require_once(__DIR__ . '/../../../../../../behat/behat_base.php');
+require_once(__DIR__ . '/../../../../tests/behat/editor_tiny_helpers.php');
 
 
 /**
  * Extends general TinyMCE test to test the tiny_multilang2 plugin.
  */
-class behat_editor_tiny_multilang2 extends behat_editor_tiny {
+class behat_editor_tiny_multilang2 extends behat_base {
+    use editor_tiny_helpers;
 
     /**
      * Click on a button for the specified TinyMCE editor.


### PR DESCRIPTION
Switch from extending behat_editor_tiny to using the trait class as you should not extend behat classes as this duplicates the step definitions and causes errors when both fontcolor and multilang2 are installed