### PR TITLE
Fix format of deprecated language strings

### DIFF
--- a/lang/en/deprecated.txt
+++ b/lang/en/deprecated.txt
@@ -1,1 +1,1 @@
-helplinktext,multilang2:viewlanguagemenu
+helplinktext,tiny_multilang2


### PR DESCRIPTION
Fixes unit test fail due to format of deprecated.txt

test_validate_deprecated_strings_files with data set #267
lib

core\string_manager_standard_test::test_validate_deprecated_strings_files with data set #267 ('helplinktext,multilang2:viewl...gemenu')
Component name helplinktext,multilang2:viewlanguagemenu appearing in one of the lang/en/deprecated.txt files does not have correct syntax
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'multilang2:viewlanguagemenu'
+''
/var/www/html/lib/tests/string_manager_standard_test.php:122
/var/www/html/lib/phpunit/classes/advanced_testcase.php:76